### PR TITLE
Bower package descriptor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "haml"
   ],
   "dependencies": {
-        "jquery": "jquery"
+        "jquery": ""
   },
   "license": "MIT",
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,9 @@
     "jquery",
     "haml"
   ],
+  "dependencies": {
+        "jquery": "jquery"
+  },
   "license": "MIT",
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "jquery-haml",
+  "version": "1.3.0",
+  "homepage": "https://github.com/creationix/jquery-haml",
+  "authors": [
+    "Tim Caswell <tim@creationix.com>"
+  ],
+  "description": "jQuery-haml is haml like language written in JSON",
+  "main": "jquery.haml-1.3.js",
+  "keywords": [
+    "jquery",
+    "haml"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "examples"
+  ]
+}


### PR DESCRIPTION
What do you think about publishing jquery-haml as Bower (https://github.com/bower/bower) package?

If you will decide to accept my pull request, please also tag merged version as 1.3.0 after that.
